### PR TITLE
add MariaDB support + custom port support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,21 @@ jobs:
             fail-fast: false
             matrix:
                 php-version: [ '8.1', '8.2', '8.3', '8.4' ]
-                db-type: [ sqlite, mysql, pgsql ]
+                db-type: [ sqlite, mysql, mariadb, pgsql ]
 
         services:
+            mariadb:
+                image: mariadb:11
+                env:
+                    MARIADB_ROOT_PASSWORD: root
+                    MARIADB_DATABASE: cakephp
+                ports:
+                    - 3307:3306
+                options: >-
+                    --health-cmd "mariadb-admin ping -h localhost -proot"
+                    --health-interval 10s
+                    --health-timeout 5s
+                    --health-retries 5
             postgres:
                 image: postgres:14
                 env:
@@ -44,6 +56,10 @@ jobs:
                     sudo service mysql start
                     mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE cakephp;'
 
+            -   name: Install MariaDB dump tools
+                if: matrix.db-type == 'mariadb'
+                run: sudo apt-get install mariadb-client
+
             -   name: Setup Postgres
                 if: matrix.db-type == 'pgsql'
                 run: |
@@ -57,7 +73,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php-version }}
-                    extensions: mbstring, intl, pdo_${{ matrix.db-type }}
+                    extensions: mbstring, intl, ${{ matrix.db-type == 'sqlite' && 'pdo_sqlite' || matrix.db-type == 'pgsql' && 'pdo_pgsql' || 'pdo_mysql' }}
                     ini-values: zend.assertions=1
                     coverage: pcov
 
@@ -74,6 +90,9 @@ jobs:
                     fi
                     if [[ ${{ matrix.db-type }} == 'mysql' ]]; then
                         export DB_URL=mysql://root:root@127.0.0.1/cakephp
+                    fi
+                    if [[ ${{ matrix.db-type }} == 'mariadb' ]]; then
+                        export DB_URL=mysql://root:root@127.0.0.1:3307/cakephp
                     fi
                     if [[ ${{ matrix.db-type }} == 'pgsql' ]]; then
                         export DB_URL=postgres://postgres:postgres@127.0.0.1/postgres
@@ -107,7 +126,7 @@ jobs:
                 uses: ramsey/composer-install@v3
 
             -   name: Install PHP tools with phive.
-                run: "phive install --trust-gpg-keys 'CF1A108D0E7AE720,51C67305FFC2E5C0,12CE0F1D262429A5'"
+                run: "phive install --trust-gpg-keys '51C67305FFC2E5C0,12CE0F1D262429A5,99BF4D9A33D65E1E'"
 
             -   name: Run phpcs
                 if: always()
@@ -120,4 +139,3 @@ jobs:
             -   name: Run phpstan
                 if: always()
                 run: tools/phpstan analyse --error-format=github
-

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ public function bootstrap(): void
 
 For each DBMS you need to have its respective dump tool installed.
 
-- MySQL/MariaDB => `mysqldump`
+- MySQL => `mysqldump`
+- MariaDB => `mariadb-dump`
 - SQLite => `sqlite3`
 - PostgreSQL => `pg_dump`
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,7 +9,6 @@
 
     <php>
         <ini name="memory_limit" value="-1"/>
-        <ini name="apc.enable_cli" value="1"/>
         <env name="FIXTURE_SCHEMA_METADATA" value="./tests/schema.php"/>
         <!-- SQLite
             <env name="DB_URL" value="sqlite:///:memory:"/>

--- a/src/Command/DumpSqlCommand.php
+++ b/src/Command/DumpSqlCommand.php
@@ -67,19 +67,15 @@ class DumpSqlCommand extends Command
         }
 
         $driver = $connection->getDriver();
-        switch (get_class($driver)) {
-            case Mysql::class:
-                $object = new CakeDumpMySQL($connection->config());
-                break;
-            case Sqlite::class:
-                $object = new CakeDumpSqlite($connection->config());
-                break;
-            case Postgres::class:
-                $object = new CakeDumpPostgres($connection->config());
-                break;
-            default:
-                $message = sprintf('Unknown driver "%s" given.', get_class($driver));
-                throw new UnknownDriverException($message);
+        if ($driver instanceof Mysql) {
+            $object = new CakeDumpMySQL($connection->config(), $driver);
+        } elseif ($driver instanceof Sqlite) {
+            $object = new CakeDumpSqlite($connection->config());
+        } elseif ($driver instanceof Postgres) {
+            $object = new CakeDumpPostgres($connection->config());
+        } else {
+            $message = sprintf('Unknown driver "%s" given.', get_class($driver));
+            throw new UnknownDriverException($message);
         }
 
         $object->setIo($io);

--- a/src/Sql/MySQL.php
+++ b/src/Sql/MySQL.php
@@ -3,12 +3,26 @@ declare(strict_types=1);
 
 namespace CakeDumpSql\Sql;
 
+use Cake\Database\Driver\Mysql as MysqlDriver;
 use CakeDumpSql\Error\BinaryNotFoundException;
 use Symfony\Component\Process\Process;
 
 class MySQL extends SqlBase
 {
     protected string $command = 'mysqldump';
+
+    /**
+     * @param array<string, mixed> $config The config array from the connection object
+     * @param \Cake\Database\Driver\Mysql $driver The current mysql driver instance
+     */
+    public function __construct(array $config, protected MysqlDriver $driver)
+    {
+        parent::__construct($config);
+
+        if ($driver->isMariadb()) {
+            $this->command = 'mariadb-dump';
+        }
+    }
 
     /**
      * @return string
@@ -26,10 +40,17 @@ class MySQL extends SqlBase
             '--password="' . ($this->config['password'] ?? '') . '"',
             '--default-character-set=' . ($this->config['encoding'] ?? 'utf8mb4'),
             '--host=' . ($this->config['host'] ?? 'localhost'),
+            '--port=' . ($this->config['port'] ?? 3306),
             '--databases',
             $this->config['database'],
-            '--no-create-db',
         ];
+
+        if ($this->driver->isMariadb()) {
+            $command[] = '--skip-create-options';
+        } else {
+            $command[] = '--no-create-db';
+        }
+
         if ($this->isDataOnly()) {
             $command[] = '--no-create-info';
         }

--- a/src/Sql/PostgreSQL.php
+++ b/src/Sql/PostgreSQL.php
@@ -28,6 +28,7 @@ class PostgreSQL extends SqlBase
             'PGPASSFILE=' . $passFile,
             $this->command,
             '--host=' . ($this->config['host'] ?? 'localhost'),
+            '--port=' . ($this->config['port'] ?? 5432),
             '--username=' . ($this->config['username'] ?? ''),
             '--dbname="' . ($this->config['database'] ?? '') . '"',
         ];

--- a/tests/TestCase/Command/DumpSqlCommandTest.php
+++ b/tests/TestCase/Command/DumpSqlCommandTest.php
@@ -47,7 +47,7 @@ class DumpSqlCommandTest extends TestCase
             $this->assertOutputContains('INSERT INTO posts VALUES(');
         } elseif ($this->isDBType(Mysql::class)) {
             $this->assertOutputContains('CREATE TABLE `posts` (');
-            $this->assertOutputContains('INSERT INTO `posts` VALUES (');
+            $this->assertOutputContains('INSERT INTO `posts` VALUES');
         } elseif ($this->isDBType(Postgres::class)) {
             $this->assertOutputContains('CREATE TABLE public.posts');
             $this->assertOutputContains('COPY public.posts (id, title, created, modified) FROM stdin;');
@@ -72,7 +72,7 @@ class DumpSqlCommandTest extends TestCase
             $this->assertOutputContains('INSERT INTO posts VALUES(');
         } elseif ($this->isDBType(Mysql::class)) {
             $this->assertOutputNotContains('CREATE TABLE `posts` (');
-            $this->assertOutputContains('INSERT INTO `posts` VALUES (');
+            $this->assertOutputContains('INSERT INTO `posts` VALUES');
         } elseif ($this->isDBType(Postgres::class)) {
             $this->assertOutputNotContains('CREATE TABLE public.posts');
             $this->assertOutputContains('COPY public.posts (id, title, created, modified) FROM stdin;');
@@ -103,7 +103,7 @@ class DumpSqlCommandTest extends TestCase
             $this->assertStringContainsString('INSERT INTO posts VALUES(', $sql);
         } elseif ($this->isDBType(Mysql::class)) {
             $this->assertStringContainsString('CREATE TABLE `posts` (', $sql);
-            $this->assertStringContainsString('INSERT INTO `posts` VALUES (', $sql);
+            $this->assertStringContainsString('INSERT INTO `posts` VALUES', $sql);
         } elseif ($this->isDBType(Postgres::class)) {
             $this->assertStringContainsString('CREATE TABLE public.posts', $sql);
             $this->assertStringContainsString('COPY public.posts (id, title, created, modified) FROM stdin;', $sql);


### PR DESCRIPTION
MariaDB drift appart from MySQL more and more, therefore this replaces the `mysqldump` with the `mariadb-dump` command if the used connection is MariaDB.

While implementing this I recognised, that I didn't add custom port capability in this plugin till now 😅 